### PR TITLE
Fixed export of typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/webglplot.d.ts",
       "require": "./dist/webglplot.cjs",
       "import": "./dist/webglplot.esm.mjs"
     },


### PR DESCRIPTION
Fixed the following error which occured when I tried to use this library in my typescript project, [due to specification change of typescript](https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts).

```
src/components/valueCard.tsx:4:49 - error TS7016: Could not find a declaration file for module 'webgl-plot'. '/Users/kou/projects/webcface1/webui/node_modules/webgl-plot/dist/webglplot.esm.mjs' implicitly has an 'any' type.
  There are types at '/Users/kou/projects/webcface1/webui/node_modules/webgl-plot/dist/webglplot.d.ts', but this result could not be resolved when respecting package.json "exports". The 'webgl-plot' library may need to update its package.json or typings.

4 import { WebglPlot, WebglLine, ColorRGBA } from "webgl-plot";
                                                  ~~~~~~~~~~~~
```
